### PR TITLE
fix: layout being resized on every keystroke

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -192,7 +192,6 @@ function Sidebar:setup_colors()
         ::continue::
       end
       self:set_code_winhl()
-      self:adjust_layout()
     end,
   })
 end


### PR DESCRIPTION
If we resize the window manually, avante will reset it to default layout on every keystroke, making it impossible to resize the layout ourselves.

Expected is for avante to only set the window sizes on first render, then allow user to resize if he wants.
